### PR TITLE
Dockerize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ build/
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /bin/
+
+# Vagrant Files #
+.vagrant

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vagrant"]
-	path = vagrant
-	url = git://github.com/Sch3lp/ubuntu1404-mongodb26.git

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,12 +1,10 @@
-#How to contribute
-
+# How to contribute
 ## Setting up your environment
 Fork [this repo](https://github.com/SoftwareSandbox/Fiazard/) into your own account, e.g. `git@github.com:MyGithubAccount/Fiazard.git` and clone your forked repo locally:  
 ```
-git clone https://github.com/MyGithubAccount/Fiazard --recursive
+git clone https://github.com/MyGithubAccount/Fiazard
 git remote add swsb https://github.com/SoftwareSandbox/Fiazard
 ```  
-This will also clone the repo in the vagrant folder, which will set up your MongoDB environment.
 
 Install [Vagrant](http://vagrantup.com) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads).
 
@@ -18,7 +16,7 @@ After installing [Robomongo](http://robomongo.org/), add a connection to `10.11.
 Download Vagrant through https://www.vagrantup.com/downloads.html because `apt-get install vagrant` installs an older version.
 
 You'll have to download oracle's Java 8 since openjdk still has no package out yet:
-```ssh
+```
 sudo add-apt-repository ppa:webupd8team/java
 sudo apt-get update
 sudo apt-get install oracle-java8-installer
@@ -26,12 +24,11 @@ sudo apt-get install oracle-java8-set-default
 ```
 
 ## EventStore
-
 Install [Docker](https://www.docker.com/) on Ubuntu, or [DockerToolbox](https://www.docker.com/docker-toolbox) on Windows.
 DockerToolbox will start Docker inside a VirtualBox machine. Make sure you have a recent (5.0.3 or up) VirtualBox installation. Otherwhise, you might get an IP conflict between Windows and Docker-machine.
 
 Pull the [adbrowne/eventstore](https://hub.docker.com/r/adbrowne/eventstore/) docker container and run it with
-```ssh
+```
 sudo docker run -d -p 2113:2113 -p 1113:1113 adbrowne/eventstore
 ```
 Access the Web UI via [http://localhost:2113/web/index.html](http://localhost:2113/web/index.html).
@@ -51,7 +48,7 @@ gradlew startAppDev
 ```
 or make a target in your IDE that runs `FiazardApp.java` with arguments `server src/main/resources/dev.yml`.
 
-##Pick up backlog items
+## Pick up backlog items
 1. Pick up a backlog item at [waffle.io](https://waffle.io/softwaresandbox/fiazard) and assign it to yourself
 2. Make sure you are in sync with the latest version of the repository:  
   `git pull swsb master`
@@ -70,7 +67,6 @@ or make a target in your IDE that runs `FiazardApp.java` with arguments `server 
   `git push --delete origin feature-branch-{featureId}`
 
 ## Some Conventions
-
 Always suffix Representation classes (java classes that will be transformed into JSON by Jackson) with an R.
 
 `OpeningHour.java` becomes `OpeningHourR.java`

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -8,10 +8,6 @@ git remote add swsb https://github.com/SoftwareSandbox/Fiazard
 
 Install [Vagrant](http://vagrantup.com) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads).
 
-Open up a shell, navigate to the vagrant dir and type `vagrant up`. This will download an Ubuntu 14.x VM box and install MongoDB Client and Server 2.6. For more info check this [forked repo](https://github.com/Sch3lp/ubuntu1404-mongodb26).
-
-After installing [Robomongo](http://robomongo.org/), add a connection to `10.11.12.13:27017`.
-
 ### On Ubuntu
 Download Vagrant through https://www.vagrantup.com/downloads.html because `apt-get install vagrant` installs an older version.
 
@@ -22,24 +18,19 @@ sudo apt-get update
 sudo apt-get install oracle-java8-installer
 sudo apt-get install oracle-java8-set-default
 ```
+## Vagrant
+Open up a shell, navigate to the vagrant dir and type `vagrant up`. This will set up an environment with MongoDB and EventStore.
 
-## EventStore
-Install [Docker](https://www.docker.com/) on Ubuntu, or [DockerToolbox](https://www.docker.com/docker-toolbox) on Windows.
-DockerToolbox will start Docker inside a VirtualBox machine. Make sure you have a recent (5.0.3 or up) VirtualBox installation. Otherwhise, you might get an IP conflict between Windows and Docker-machine.
+The [Vagrantfile](vagrant/Vagrantfile) downloads an Ubuntu 14.x VM and handles port forwarding. It uses [Docker](https://www.docker.com) to provision the VM with MongoDB and EventStore. This is configured in [docker-compose.yml](vagrant/docker-compose.yml).
 
-Pull the [adbrowne/eventstore](https://hub.docker.com/r/adbrowne/eventstore/) docker container and run it with
-```
-sudo docker run -d -p 2113:2113 -p 1113:1113 adbrowne/eventstore
-```
+### MongoDB
+After installing [Robomongo](http://robomongo.org/), add a connection to `localhost:27017`.
+
+### EventStore
 Access the Web UI via [http://localhost:2113/web/index.html](http://localhost:2113/web/index.html).
-To make this work on Windows, you'll have to setup port-forwarding on the VirtualBox machine.
-In VirtualBox Manager, right click 'default', then choose 'Instellingen', 'Netwerk', 'Poortdoorverwijzing'.
-Add one rule for TCP, 127.0.0.1, 1113, 1113 and one rule for TCP, 127.0.0.1, 2113, 2113.
-
-Alternatively, on Windows, if you don't want to use Docker, you can install [EventStore](http://geteventstore.com) natively. However, if we're going to customize a docker container for event store, you might get into trouble...
 
 ## Gradle
-There's no need to download and install Gradle, use the gradlewrapper (gradlew in the root) to run your builds.
+There's no need to download and install Gradle, use the gradle wrapper (gradlew in the root) to run your builds.
 
 ### Running your Dropwizard Application locally
 Simply run 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,21 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+unless Vagrant.has_plugin?("vagrant-docker-compose")
+  system("vagrant plugin install vagrant-docker-compose")
+  puts "Dependencies installed, please try the command again."
+  exit
+end
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.network :forwarded_port, host: 27017, guest: 27017
+  config.vm.network :forwarded_port, host: 2113, guest: 2113
+  config.vm.network :forwarded_port, host: 1113, guest: 1113
+  config.vm.provision :docker
+  config.vm.provision :docker_compose,
+    yml: "/vagrant/docker-compose.yml",
+    rebuild: true,
+    project_name: "fiazard",
+    run: "always"
+end

--- a/vagrant/docker-compose.yml
+++ b/vagrant/docker-compose.yml
@@ -1,0 +1,9 @@
+mongo:
+  image: mongo
+  ports:
+    - "0.0.0.0:27017:27017"
+eventstore:
+  image: adbrowne/eventstore
+  ports:
+    - "0.0.0.0:2113:2113"
+    - "0.0.0.0:1113:1113"


### PR DESCRIPTION
I removed the Vagrant submodule and replaced it with a simple Vagrantfile that uses Docker compose to provision an Ubuntu VM. The VM contains a MongoDB Docker container and an EventStore Docker container. Vagrant handles the port forwarding. 
I updated the Contribute.MD where you can read how to use it.